### PR TITLE
test: Wait for MCP tool registration before chat agent IT execute

### DIFF
--- a/build-tools/repositories.gradle
+++ b/build-tools/repositories.gradle
@@ -6,6 +6,7 @@
 repositories {
     mavenLocal()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven {url 'https://oss.sonatype.org/content/repositories/snapshots/'}
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/lucene/" }

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ buildscript {
     repositories {
         mavenLocal()
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/lucene/" }

--- a/ml-algorithms/build.gradle
+++ b/ml-algorithms/build.gradle
@@ -14,6 +14,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java
@@ -815,37 +815,52 @@ public class AgentUtils {
             String connectorId = (String) mcpConnectorConfig.get(MCP_CONNECTOR_ID_FIELD);
             List<String> toolFilters = (List<String>) mcpConnectorConfig.get(TOOL_FILTERS_FIELD);
 
-            getMCPToolSpecsFromConnector(connectorId, tenantId, sdkClient, client, encryptor, ActionListener.wrap(mcpToolspecs -> {
-                List<MLToolSpec> filteredTools;
-                if (toolFilters == null || toolFilters.isEmpty()) {
-                    filteredTools = mcpToolspecs;
-                } else {
-                    filteredTools = new ArrayList<>();
-                    List<Pattern> compiledPatterns = toolFilters.stream().map(Pattern::compile).collect(Collectors.toList());
+            try {
+                getMCPToolSpecsFromConnector(connectorId, tenantId, sdkClient, client, encryptor, ActionListener.wrap(mcpToolspecs -> {
+                    try {
+                        List<MLToolSpec> filteredTools;
+                        if (toolFilters == null || toolFilters.isEmpty()) {
+                            filteredTools = mcpToolspecs;
+                        } else {
+                            filteredTools = new ArrayList<>();
+                            List<Pattern> compiledPatterns = toolFilters.stream().map(Pattern::compile).collect(Collectors.toList());
 
-                    for (MLToolSpec toolSpec : mcpToolspecs) {
-                        for (Pattern pattern : compiledPatterns) {
-                            if (pattern.matcher(toolSpec.getName()).matches()) {
-                                filteredTools.add(toolSpec);
-                                break;
+                            for (MLToolSpec toolSpec : mcpToolspecs) {
+                                for (Pattern pattern : compiledPatterns) {
+                                    if (pattern.matcher(toolSpec.getName()).matches()) {
+                                        filteredTools.add(toolSpec);
+                                        break;
+                                    }
+                                }
                             }
                         }
+
+                        finalToolSpecs.addAll(filteredTools);
+                    } catch (Throwable t) {
+                        log.error("Error post-processing MCP tool specs for connector: " + connectorId, t);
+                    } finally {
+                        completeIfLast(remainingConnectors, finalToolSpecs, finalListener);
                     }
-                }
+                }, e -> {
+                    log.error("Error processing connector: " + connectorId, e);
+                    completeIfLast(remainingConnectors, finalToolSpecs, finalListener);
+                }));
+            } catch (Throwable t) {
+                // Catch synchronous throws (including Errors) so one bad connector can't strand the counter.
+                log.error("Synchronous failure initiating MCP tool spec lookup for connector: " + connectorId, t);
+                completeIfLast(remainingConnectors, finalToolSpecs, finalListener);
+            }
+        }
+    }
 
-                finalToolSpecs.addAll(filteredTools);
-
-                // If this is the last connector, send the final response
-                if (remainingConnectors.decrementAndGet() == 0) {
-                    finalListener.onResponse(finalToolSpecs);
-                }
-            }, e -> {
-                log.error("Error processing connector: " + connectorId, e);
-                // Even on error, we need to check if this is the last connector
-                if (remainingConnectors.decrementAndGet() == 0) {
-                    finalListener.onResponse(finalToolSpecs);
-                }
-            }));
+    // Guarantees the final listener fires exactly once; every code path decrements via try/finally.
+    private static void completeIfLast(
+        AtomicInteger remainingConnectors,
+        List<MLToolSpec> finalToolSpecs,
+        ActionListener<List<MLToolSpec>> finalListener
+    ) {
+        if (remainingConnectors.decrementAndGet() == 0) {
+            finalListener.onResponse(finalToolSpecs);
         }
     }
 
@@ -893,12 +908,13 @@ public class AgentUtils {
                     toolListener.onFailure(e);
                 });
                 connector.decrypt("", encryptor::decrypt, tenantId, decryptSuccessfulListener);
-            } catch (Exception e) {
-                log.error("Failed to get tools from connector: " + connectorId, e);
+            } catch (Throwable t) {
+                // Throwable, not Exception: ServiceConfigurationError would otherwise stall the async chain.
+                log.error("Error retrieving MCP tool specs from connector: " + connectorId, t);
                 toolListener.onResponse(Collections.emptyList());
             }
         }, e -> {
-            log.error("Failed to get the MCP Connector: " + connectorId, e);
+            log.error("Failed to get connector for MCP tool specs, connectorId=" + connectorId, e);
             toolListener.onResponse(Collections.emptyList());
         }));
 

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/MLChatAgentRunner.java
@@ -1685,23 +1685,27 @@ public class MLChatAgentRunner implements MLAgentRunner {
         getMcpToolSpecs(mlAgent, client, sdkClient, encryptor, ActionListener.wrap(mcpTools -> {
             // Add MCP tools to backend tools
             backendToolSpecs.addAll(mcpTools);
-
-            // Create backend tools map
-            Map<String, Tool> backendToolsMap = new HashMap<>();
-            Map<String, MLToolSpec> toolSpecMap = new HashMap<>();
-            createTools(toolFactories, params, backendToolSpecs, backendToolsMap, toolSpecMap, mlAgent);
-
-            // Create unified tool list for function calling (frontend + backend)
-            processUnifiedToolsWithBackend(mlAgent, params, listener, memory, functionCalling, frontendTools, backendToolsMap, toolSpecMap);
+            buildAndProcessUnifiedTools(mlAgent, params, listener, memory, functionCalling, frontendTools, backendToolSpecs);
         }, e -> {
             // Even if MCP tools fail, continue with base backend tools
-
-            Map<String, Tool> backendToolsMap = new HashMap<>();
-            Map<String, MLToolSpec> toolSpecMap = new HashMap<>();
-            createTools(toolFactories, params, backendToolSpecs, backendToolsMap, toolSpecMap, mlAgent);
-
-            processUnifiedToolsWithBackend(mlAgent, params, listener, memory, functionCalling, frontendTools, backendToolsMap, toolSpecMap);
+            log.warn("Failed to load MCP tools, continuing with backend tools only", e);
+            buildAndProcessUnifiedTools(mlAgent, params, listener, memory, functionCalling, frontendTools, backendToolSpecs);
         }));
+    }
+
+    private void buildAndProcessUnifiedTools(
+        MLAgent mlAgent,
+        Map<String, String> params,
+        ActionListener<Object> listener,
+        Memory memory,
+        FunctionCalling functionCalling,
+        List<Map<String, Object>> frontendTools,
+        List<MLToolSpec> backendToolSpecs
+    ) {
+        Map<String, Tool> backendToolsMap = new HashMap<>();
+        Map<String, MLToolSpec> toolSpecMap = new HashMap<>();
+        createTools(toolFactories, params, backendToolSpecs, backendToolsMap, toolSpecMap, mlAgent);
+        processUnifiedToolsWithBackend(mlAgent, params, listener, memory, functionCalling, frontendTools, backendToolsMap, toolSpecMap);
     }
 
     /**

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/PromptTemplate.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/PromptTemplate.java
@@ -138,6 +138,7 @@ public class PromptTemplate {
             - If the available data is insufficient to complete the Step, summarize what was obtained so far and clearly state the additional information or access required to proceed (do not guess).
             - If unable to complete the Step, clearly explain what went wrong and what is needed to proceed.
             - Avoid making assumptions and relying on implicit knowledge.
+            - Before generating any PPL or DSL query, always retrieve the index mapping first to ensure correct field names. Do not guess field names.
             - Your response must be self-contained and ready for the planner to use without modification. Never end with a question.
             - Break complex searches into simpler queries when appropriate.
             - Never invoke more than one tool in a single response. Returning multiple tool calls in one response is invalid.""";

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutor.java
@@ -47,6 +47,10 @@ import com.google.gson.Gson;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapperSupplier;
+import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
+import io.modelcontextprotocol.json.schema.jackson3.JacksonJsonSchemaValidatorSupplier;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 import lombok.Getter;
@@ -56,6 +60,11 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 @ConnectorExecutor(MCP_SSE)
 public class McpConnectorExecutor extends AbstractConnectorExecutor {
+
+    // Cached singletons; the suppliers' outputs are thread-safe and the schema validator caches compiled schemas.
+    // Explicit instances also bypass the MCP SDK's ServiceLoader lookup, which fails under plugin classloader isolation.
+    private static final McpJsonMapper JSON_MAPPER = new JacksonMcpJsonMapperSupplier().get();
+    private static final JsonSchemaValidator JSON_SCHEMA_VALIDATOR = new JacksonJsonSchemaValidatorSupplier().get();
 
     @Getter
     private McpConnector connector;
@@ -88,9 +97,9 @@ public class McpConnectorExecutor extends AbstractConnectorExecutor {
                 getMcpRequestHeaders(builder);
             };
 
-            // Create transport
             McpClientTransport transport = HttpClientSseClientTransport
                 .builder(mcpServerUrl)
+                .jsonMapper(JSON_MAPPER)
                 .sseEndpoint(sseEndpoint)
                 .customizeClient(clientBuilder -> {
                     clientBuilder.connectTimeout(connectionTimeout);
@@ -98,11 +107,11 @@ public class McpConnectorExecutor extends AbstractConnectorExecutor {
                 .customizeRequest(headerConfig)
                 .build();
 
-            // Create and initialize client
             McpSyncClient client = McpClient
                 .sync(transport)
                 .requestTimeout(readTimeout)
                 .capabilities(McpSchema.ClientCapabilities.builder().roots(false).build())
+                .jsonSchemaValidator(JSON_SCHEMA_VALIDATOR)
                 .build();
 
             client.initialize();

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutor.java
@@ -49,6 +49,10 @@ import com.google.gson.Gson;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapperSupplier;
+import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
+import io.modelcontextprotocol.json.schema.jackson3.JacksonJsonSchemaValidatorSupplier;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 import lombok.Getter;
@@ -58,6 +62,11 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 @ConnectorExecutor(MCP_STREAMABLE_HTTP)
 public class McpStreamableHttpConnectorExecutor extends AbstractConnectorExecutor {
+
+    // Cached singletons; the suppliers' outputs are thread-safe and the schema validator caches compiled schemas.
+    // Explicit instances also bypass the MCP SDK's ServiceLoader lookup, which fails under plugin classloader isolation.
+    private static final McpJsonMapper JSON_MAPPER = new JacksonMcpJsonMapperSupplier().get();
+    private static final JsonSchemaValidator JSON_SCHEMA_VALIDATOR = new JacksonJsonSchemaValidatorSupplier().get();
 
     @Getter
     private McpStreamableHttpConnector connector;
@@ -91,9 +100,9 @@ public class McpStreamableHttpConnectorExecutor extends AbstractConnectorExecuto
                 getMcpRequestHeaders(builder);
             };
 
-            // Create streamable HTTP transport
             McpClientTransport transport = HttpClientStreamableHttpTransport
                 .builder(mcpServerUrl)
+                .jsonMapper(JSON_MAPPER)
                 .endpoint(endpoint)
                 .customizeClient(clientBuilder -> {
                     clientBuilder.connectTimeout(connectionTimeout);
@@ -102,11 +111,11 @@ public class McpStreamableHttpConnectorExecutor extends AbstractConnectorExecuto
                 .customizeRequest(headerConfig)
                 .build();
 
-            // Create and initialize client
             McpSyncClient client = McpClient
                 .sync(transport)
                 .requestTimeout(readTimeout)
                 .capabilities(McpSchema.ClientCapabilities.builder().roots(false).build())
+                .jsonSchemaValidator(JSON_SCHEMA_VALIDATOR)
                 .build();
 
             client.initialize();

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/agent/AgentUtilsTest.java
@@ -1981,6 +1981,57 @@ public class AgentUtilsTest extends MLStaticMockBase {
     }
 
     @Test
+    public void testGetMcpToolSpecs_ErrorInGetMcpToolSpecsDoesNotHang() throws Exception {
+        // Regression test for the MCP SDK 1.1.1 hang: ServiceConfigurationError is an Error (not an
+        // Exception), so a naive catch(Exception) would have let it escape and leave the async
+        // counter in getMcpToolSpecs stranded, hanging the agent forever.
+        stubGetConnector();
+
+        try (
+            MockedStatic<Connector> connStatic = mockStatic(Connector.class);
+            MockedStatic<MLEngineClassLoader> loadStatic = mockStatic(MLEngineClassLoader.class)
+        ) {
+            mockMcpConnector(connStatic);
+            McpConnectorExecutor exec = mock(McpConnectorExecutor.class);
+            when(exec.getMcpToolSpecs()).thenThrow(new java.util.ServiceConfigurationError("boom"));
+            loadStatic.when(() -> MLEngineClassLoader.initInstance(anyString(), any(), any())).thenReturn(exec);
+
+            MLAgent mlAgent = mockAgent("[{\"" + MCP_CONNECTOR_ID_FIELD + "\":\"c1\"}]", "tenant");
+            ActionListener<List<MLToolSpec>> listener = mock(ActionListener.class);
+
+            AgentUtils.getMcpToolSpecs(mlAgent, client, sdkClient, null, listener);
+            verify(listener).onResponse(Collections.emptyList());
+        }
+    }
+
+    @Test
+    public void testGetMcpToolSpecs_OneConnectorFailsOthersSucceed() throws Exception {
+        // Regression test: one connector throwing an Error must not strand the AtomicInteger
+        // counter and prevent the listener from firing for the remaining connectors.
+        stubGetConnector();
+
+        List<MLToolSpec> goodTools = List.of(buildTool("good1"));
+
+        try (
+            MockedStatic<Connector> connStatic = mockStatic(Connector.class);
+            MockedStatic<MLEngineClassLoader> loadStatic = mockStatic(MLEngineClassLoader.class)
+        ) {
+            mockMcpConnector(connStatic);
+            McpConnectorExecutor exec = mock(McpConnectorExecutor.class);
+            when(exec.getMcpToolSpecs()).thenThrow(new java.util.ServiceConfigurationError("boom")).thenReturn(goodTools);
+            loadStatic.when(() -> MLEngineClassLoader.initInstance(anyString(), any(), any())).thenReturn(exec);
+
+            String mcpJsonConfig = "[{\"" + MCP_CONNECTOR_ID_FIELD + "\":\"bad\"}," + "{\"" + MCP_CONNECTOR_ID_FIELD + "\":\"good\"}]";
+            MLAgent agent = mockAgent(mcpJsonConfig, "tenant");
+            ActionListener<List<MLToolSpec>> listener = mock(ActionListener.class);
+
+            AgentUtils.getMcpToolSpecs(agent, client, sdkClient, encryptor, listener);
+            // Listener fires exactly once with just the good connector's tools.
+            verify(listener).onResponse(goodTools);
+        }
+    }
+
+    @Test
     public void testGetMcpToolSpecs_ExceptionInGetConnector() throws Exception {
         // Mock getConnector to throw an exception
         threadContext = new ThreadContext(Settings.builder().build());

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpConnectorExecutorTest.java
@@ -51,6 +51,7 @@ public class McpConnectorExecutorTest extends MLStaticMockBase {
         /* ---------- stub the fluent builder chain ------------------------ */
         when(builder.requestTimeout(any())).thenReturn(builder);
         when(builder.capabilities(any())).thenReturn(builder);
+        when(builder.jsonSchemaValidator(any())).thenReturn(builder);
         when(builder.build()).thenReturn(mcpClient);
     }
 

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/McpStreamableHttpConnectorExecutorTest.java
@@ -51,6 +51,7 @@ public class McpStreamableHttpConnectorExecutorTest extends MLStaticMockBase {
         /* ---------- stub the fluent builder chain ------------------------ */
         when(builder.requestTimeout(any())).thenReturn(builder);
         when(builder.capabilities(any())).thenReturn(builder);
+        when(builder.jsonSchemaValidator(any())).thenReturn(builder);
         when(builder.build()).thenReturn(mcpClient);
     }
 

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -726,8 +726,8 @@ configurations.all {
     resolutionStrategy.force "io.netty:netty-handler:${versions.netty}"
     resolutionStrategy.force "io.netty:netty-resolver:${versions.netty}"
     resolutionStrategy.force "io.netty:netty-transport-native-unix-common:${versions.netty}"
-    resolutionStrategy.force 'org.apache.logging.log4j:log4j-api:2.25.3'
-    resolutionStrategy.force 'org.apache.logging.log4j:log4j-core:2.25.3'
+    resolutionStrategy.force "org.apache.logging.log4j:log4j-api:${versions.log4j}"
+    resolutionStrategy.force "org.apache.logging.log4j:log4j-core:${versions.log4j}"
 }
 
 apply plugin: 'com.netflix.nebula.ospackage'

--- a/plugin/src/test/java/org/opensearch/ml/action/connector/UpdateConnectorTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/connector/UpdateConnectorTransportActionTests.java
@@ -469,6 +469,76 @@ public class UpdateConnectorTransportActionTests extends OpenSearchTestCase {
         assertEquals(Result.UPDATED, argumentCaptor.getValue().getResult());
     }
 
+    @Test
+    public void testExecuteWithValidDynamicHeaders() {
+        doReturn(true).when(connectorAccessControlHelper).validateConnectorAccess(any(Client.class), any(Connector.class));
+
+        MLCreateConnectorInput updateContent = MLCreateConnectorInput
+            .builder()
+            .updateConnector(true)
+            .version("2")
+            .actions(
+                Arrays
+                    .asList(
+                        ConnectorAction
+                            .builder()
+                            .actionType(ConnectorAction.ActionType.PREDICT)
+                            .method("POST")
+                            .url("https://api.openai.com/v1/chat/completions")
+                            .headers(Map.of("X-Custom-Header", "${parameters.custom_value}"))
+                            .requestBody("{ \"model\": \"${parameters.model}\" }")
+                            .build()
+                    )
+            )
+            .build();
+        when(updateRequest.getUpdateContent()).thenReturn(updateContent);
+
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> actionListener = invocation.getArgument(1);
+            actionListener.onResponse(searchResponse);
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> listener = invocation.getArgument(1);
+            listener.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(UpdateRequest.class), isA(ActionListener.class));
+
+        updateConnectorTransportAction.doExecute(task, updateRequest, actionListener);
+        verify(actionListener).onResponse(any(UpdateResponse.class));
+    }
+
+    @Test
+    public void testExecuteWithBlockedDynamicHeaderThrowsException() {
+        doReturn(true).when(connectorAccessControlHelper).validateConnectorAccess(any(Client.class), any(Connector.class));
+
+        MLCreateConnectorInput updateContent = MLCreateConnectorInput
+            .builder()
+            .updateConnector(true)
+            .version("2")
+            .actions(
+                Arrays
+                    .asList(
+                        ConnectorAction
+                            .builder()
+                            .actionType(ConnectorAction.ActionType.PREDICT)
+                            .method("POST")
+                            .url("https://api.openai.com/v1/chat/completions")
+                            .headers(Map.of("Authorization", "${parameters.token}"))
+                            .requestBody("{ \"model\": \"${parameters.model}\" }")
+                            .build()
+                    )
+            )
+            .build();
+        when(updateRequest.getUpdateContent()).thenReturn(updateContent);
+
+        updateConnectorTransportAction.doExecute(task, updateRequest, actionListener);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertTrue(argumentCaptor.getValue().getMessage().contains("cannot use ${parameters.*} placeholders for security reasons"));
+    }
+
     private SearchResponse noneEmptySearchResponse() throws IOException {
         String modelContent = "{\"name\":\"Remote_Model\",\"algorithm\":\"Remote\",\"version\":1,\"connector_id\":\"test_id\"}";
         SearchHit model = SearchHit.fromXContent(TestHelper.parser(modelContent));

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestChatAgentWithMcpConnectorIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestChatAgentWithMcpConnectorIT.java
@@ -77,6 +77,19 @@ public class RestChatAgentWithMcpConnectorIT extends MLCommonsRestTestCase {
             );
         assertEquals(200, registerResponse.getStatusLine().getStatusCode());
 
+        // MCP per-node tool registration is fire-and-forget, so HTTP 200 doesn't guarantee
+        // the tool is visible yet. Poll /_list until ListIndexTool shows up (15s max).
+        Thread.sleep(500);
+        long deadline = System.currentTimeMillis() + 15_000;
+        while (System.currentTimeMillis() < deadline) {
+            Response listResponse = TestHelper
+                .makeRequest(client(), "GET", "/_plugins/_ml/mcp/tools/_list", null, "", null);
+            if (TestHelper.httpEntityToString(listResponse.getEntity()).contains("ListIndexTool")) {
+                break;
+            }
+            Thread.sleep(500);
+        }
+
         ingestIrisData(irisIndex);
         llmModelId = registerAndDeployBedrockModel();
     }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestChatAgentWithMcpConnectorIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestChatAgentWithMcpConnectorIT.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.opensearch.client.Response;
+import org.opensearch.ml.common.MLTaskState;
+import org.opensearch.ml.utils.TestHelper;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Integration test for a conversational agent backed by an MCP streamable-http connector that
+ * points at the very same cluster (which also hosts an MCP server at /_plugins/_ml/mcp).
+ *
+ * <p>This exercises the full MCP-client path end-to-end:
+ * <ol>
+ *   <li>Register ListIndexTool with the cluster's MCP server.</li>
+ *   <li>Create an MCP streamable-http connector whose URL is the cluster's own HTTP endpoint.</li>
+ *   <li>Register a conversational agent wired to Bedrock Claude plus the MCP connector.</li>
+ *   <li>Execute the agent with an "list indices" question and assert that the pre-seeded
+ *       iris_data index shows up in the final response — which can only happen if the MCP
+ *       tool list succeeded and ListIndexTool was actually invoked.</li>
+ * </ol>
+ *
+ * <p>Requires {@code AWS_ACCESS_KEY_ID} + {@code AWS_SECRET_ACCESS_KEY} (and optionally
+ * {@code AWS_SESSION_TOKEN}); skipped automatically when absent.
+ */
+public class RestChatAgentWithMcpConnectorIT extends MLCommonsRestTestCase {
+
+    private static final String AWS_ACCESS_KEY_ID = System.getenv("AWS_ACCESS_KEY_ID");
+    private static final String AWS_SECRET_ACCESS_KEY = System.getenv("AWS_SECRET_ACCESS_KEY");
+    private static final String AWS_SESSION_TOKEN = System.getenv("AWS_SESSION_TOKEN");
+    private static final String REGION = "us-west-2";
+    private static final String MODEL_ID_BEDROCK = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
+
+    // Random suffix so the LLM can't hallucinate the canonical "iris_data" and pass the assertion
+    // without actually calling ListIndexTool through MCP.
+    private final String irisIndex = "iris_data_mcp_it_" + randomAlphaOfLength(8).toLowerCase(Locale.ROOT);
+    private String llmModelId;
+
+    @Before
+    public void setup() throws IOException, ParseException, InterruptedException {
+        Assume.assumeNotNull(AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY);
+
+        RestMLRemoteInferenceIT.disableClusterConnectorAccessControl();
+        updateClusterSettings("plugins.ml_commons.memory_feature_enabled", true);
+        updateClusterSettings("plugins.ml_commons.only_run_on_ml_node", false);
+        updateClusterSettings("plugins.ml_commons.trusted_connector_endpoints_regex", List.of("^.*$"));
+        updateClusterSettings("plugins.ml_commons.mcp_connector_enabled", true);
+        updateClusterSettings("plugins.ml_commons.mcp_server_enabled", true);
+
+        // Register ListIndexTool with the cluster's MCP server so the MCP client can discover it.
+        String toolRegistrationBody = "{\"tools\":[{\"name\":\"ListIndexTool\",\"type\":\"ListIndexTool\"}]}";
+        Response registerResponse = TestHelper
+            .makeRequest(
+                client(),
+                "POST",
+                "/_plugins/_ml/mcp/tools/_register",
+                null,
+                toolRegistrationBody,
+                ImmutableList.of(new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json"))
+            );
+        assertEquals(200, registerResponse.getStatusLine().getStatusCode());
+
+        ingestIrisData(irisIndex);
+        llmModelId = registerAndDeployBedrockModel();
+    }
+
+    @After
+    public void teardown() throws IOException {
+        if (AWS_ACCESS_KEY_ID == null || AWS_SECRET_ACCESS_KEY == null) {
+            return;
+        }
+        try {
+            TestHelper
+                .makeRequest(
+                    client(),
+                    "POST",
+                    "/_plugins/_ml/mcp/tools/_remove",
+                    null,
+                    "[\"ListIndexTool\"]",
+                    ImmutableList.of(new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json"))
+                );
+        } catch (Exception ignored) {
+            // best-effort cleanup
+        }
+        deleteIndexWithAdminClient(irisIndex);
+    }
+
+    public void testChatAgentWithMcpStreamableHttpConnector() throws IOException {
+        HttpHost host = getClusterHosts().get(0);
+        String mcpServerUrl = host.getSchemeName() + "://" + host.getHostName() + ":" + host.getPort();
+
+        // Step 1 – create the MCP streamable-http connector pointing at this cluster's own MCP server.
+        String connectorBody = "{\n"
+            + "  \"name\": \"Self MCP Connector\",\n"
+            + "  \"description\": \"MCP streamable-http connector pointing back at the same cluster's MCP server\",\n"
+            + "  \"version\": 1,\n"
+            + "  \"protocol\": \"mcp_streamable_http\",\n"
+            + "  \"url\": \""
+            + mcpServerUrl
+            + "\",\n"
+            + "  \"parameters\": {\n"
+            + "    \"endpoint\": \"/_plugins/_ml/mcp\"\n"
+            + "  },\n"
+            + "  \"credential\": {}\n"
+            + "}";
+        Response response = RestMLRemoteInferenceIT.createConnector(connectorBody);
+        String mcpConnectorId = (String) parseResponseToMap(response).get("connector_id");
+        assertNotNull(mcpConnectorId);
+
+        // Step 2 – register a conversational agent wired to Bedrock + the MCP connector.
+        String agentBody = "{\n"
+            + "  \"name\": \"Test_Chat_Agent_With_MCP\",\n"
+            + "  \"type\": \"conversational\",\n"
+            + "  \"description\": \"Conversational agent that lists indices via an MCP tool\",\n"
+            + "  \"llm\": {\n"
+            + "    \"model_id\": \""
+            + llmModelId
+            + "\",\n"
+            + "    \"parameters\": {\n"
+            + "      \"prompt\": \"${parameters.question}\"\n"
+            + "    }\n"
+            + "  },\n"
+            + "  \"parameters\": {\n"
+            + "    \"_llm_interface\": \"bedrock/converse/claude\",\n"
+            + "    \"mcp_connectors\": [\n"
+            + "      {\n"
+            + "        \"mcp_connector_id\": \""
+            + mcpConnectorId
+            + "\",\n"
+            + "        \"tool_filters\": []\n"
+            + "      }\n"
+            + "    ]\n"
+            + "  },\n"
+            + "  \"memory\": {\n"
+            + "    \"type\": \"conversation_index\"\n"
+            + "  }\n"
+            + "}";
+        response = TestHelper
+            .makeRequest(client(), "POST", "/_plugins/_ml/agents/_register", null, TestHelper.toHttpEntity(agentBody), null);
+        String agentId = (String) parseResponseToMap(response).get("agent_id");
+        assertNotNull(agentId);
+
+        // Step 3 – execute. The LLM must pick ListIndexTool (sourced via MCP) to answer this.
+        response = TestHelper
+            .makeRequest(
+                client(),
+                "POST",
+                "/_plugins/_ml/agents/" + agentId + "/_execute",
+                null,
+                TestHelper
+                    .toHttpEntity("{\"parameters\":{\"question\":\"Use the ListIndexTool to list user indices and return their names.\"}}"),
+                null
+            );
+        Map responseMap = parseResponseToMap(response);
+
+        List inferenceResults = (List) responseMap.get("inference_results");
+        assertNotNull(inferenceResults);
+        assertFalse(inferenceResults.isEmpty());
+
+        Map firstResult = (Map) inferenceResults.get(0);
+        List output = (List) firstResult.get("output");
+        assertNotNull(output);
+        assertFalse(output.isEmpty());
+
+        // The index name carries a random suffix seeded at test time, so the LLM cannot produce it
+        // without the actual ListIndexTool output flowing back through MCP. Substring-matching this
+        // exact name is therefore a sufficient proof that the MCP tool was invoked end-to-end.
+        String finalResponse = output.toString();
+        assertTrue(
+            "Expected randomized index name '" + irisIndex + "' to appear in agent response, got: " + finalResponse,
+            finalResponse.contains(irisIndex)
+        );
+    }
+
+    private String registerAndDeployBedrockModel() throws IOException, InterruptedException {
+        String sessionTokenLine = AWS_SESSION_TOKEN != null ? "    \"session_token\": \"" + AWS_SESSION_TOKEN + "\"\n" : "";
+        String connectorBody = "{\n"
+            + "  \"name\": \"Bedrock Claude Connector\",\n"
+            + "  \"description\": \"Connector for AWS Bedrock Claude (converse API)\",\n"
+            + "  \"version\": 1,\n"
+            + "  \"protocol\": \"aws_sigv4\",\n"
+            + "  \"parameters\": {\n"
+            + "    \"region\": \""
+            + REGION
+            + "\",\n"
+            + "    \"service_name\": \"bedrock\",\n"
+            + "    \"model\": \""
+            + MODEL_ID_BEDROCK
+            + "\"\n"
+            + "  },\n"
+            + "  \"credential\": {\n"
+            + "    \"access_key\": \""
+            + AWS_ACCESS_KEY_ID
+            + "\",\n"
+            + "    \"secret_key\": \""
+            + AWS_SECRET_ACCESS_KEY
+            + "\",\n"
+            + sessionTokenLine
+            + "  },\n"
+            + "  \"actions\": [\n"
+            + "    {\n"
+            + "      \"action_type\": \"predict\",\n"
+            + "      \"method\": \"POST\",\n"
+            + "      \"url\": \"https://bedrock-runtime."
+            + REGION
+            + ".amazonaws.com/model/"
+            + MODEL_ID_BEDROCK
+            + "/converse\",\n"
+            + "      \"headers\": {\n"
+            + "        \"content-type\": \"application/json\",\n"
+            + "        \"x-amz-content-sha256\": \"required\"\n"
+            + "      },\n"
+            + "      \"request_body\": \"{\\\"system\\\": [{\\\"text\\\": \\\"You are a helpful assistant.\\\"}], \\\"messages\\\": [${parameters._chat_history:-}{\\\"role\\\":\\\"user\\\",\\\"content\\\":[{\\\"text\\\":\\\"${parameters.prompt}\\\"}]}${parameters._interactions:-}]${parameters.tool_configs:-} }\"\n"
+            + "    }\n"
+            + "  ]\n"
+            + "}";
+
+        Response response = RestMLRemoteInferenceIT.createConnector(connectorBody);
+        String connectorId = (String) parseResponseToMap(response).get("connector_id");
+        assertNotNull(connectorId);
+
+        response = RestMLRemoteInferenceIT.registerRemoteModel("bedrock_claude_mcp_model", connectorId);
+        String taskId = (String) parseResponseToMap(response).get("task_id");
+        assertNotNull(taskId);
+        waitForTask(taskId, MLTaskState.COMPLETED);
+
+        response = TestHelper.makeRequest(client(), "GET", "/_plugins/_ml/tasks/" + taskId, null, "", null);
+        String modelId = (String) parseResponseToMap(response).get("model_id");
+        assertNotNull(modelId);
+
+        response = RestMLRemoteInferenceIT.deployRemoteModel(modelId);
+        taskId = (String) parseResponseToMap(response).get("task_id");
+        assertNotNull(taskId);
+        waitForTask(taskId, MLTaskState.COMPLETED);
+
+        return modelId;
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLRemoteInferenceIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLRemoteInferenceIT.java
@@ -1133,11 +1133,10 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
             + "      \"method\": \"POST\",\n"
             + "      \"url\": \"https://${parameters.endpoint}/post\",\n"
             + "      \"headers\": {\n"
-            + "        \"X-Request-ID\": \"${parameters.request_id}\",\n"
+            + "        \"X-Custom-Request\": \"${parameters.request_id}\",\n"
             + "        \"X-Model\": \"${parameters.model}\"\n"
             + "      },\n"
-            + "      \"request_body\": \"{\\\"input\\\": \\\"${parameters.input}\\\"}\",\n"
-            + "      \"post_process_function\": \"return params.response;\"\n"
+            + "      \"request_body\": \"{\\\"input\\\": \\\"${parameters.input}\\\"}\"\n"
             + "    }\n"
             + "  ]\n"
             + "}";
@@ -1192,21 +1191,20 @@ public class RestMLRemoteInferenceIT extends MLCommonsRestTestCase {
 
         // httpbin returns the headers in the response
         Map headers = (Map) dataAsMap.get("headers");
-        if (headers != null) {
-            // Verify our dynamic headers were substituted correctly
-            String requestId = (String) headers.get("X-Request-Id");
-            String model = (String) headers.get("X-Model");
+        assertNotNull("httpbin response should contain headers", headers);
 
-            // httpbin may lowercase header names
-            if (requestId == null) {
-                requestId = (String) headers.get("x-request-id");
-            }
-            if (model == null) {
-                model = (String) headers.get("x-model");
-            }
+        // Verify our dynamic headers were substituted correctly
+        String requestId = (String) headers.get("X-Custom-Request");
+        String model = (String) headers.get("X-Model");
 
-            assertEquals("req-integration-test-12345", requestId);
-            assertEquals("test-model", model);
+        if (requestId == null) {
+            requestId = (String) headers.get("x-custom-request");
         }
+        if (model == null) {
+            model = (String) headers.get("x-model");
+        }
+
+        assertEquals("req-integration-test-12345", requestId);
+        assertEquals("test-model", model);
     }
 }

--- a/release-notes/opensearch-ml-commons.release-notes-3.7.0.0.md
+++ b/release-notes/opensearch-ml-commons.release-notes-3.7.0.0.md
@@ -2,5 +2,39 @@
 
 Compatible with OpenSearch and OpenSearch Dashboards version 3.7.0
 
+### Features
+
+* Add `provisioned_by` field to ML agents, connectors, and models for adoption metrics attribution ([#4754](https://github.com/opensearch-project/ml-commons/pull/4754))
+* Enable dynamic header support in ML connectors using `${parameters.*}` placeholders for per-request values ([#4817](https://github.com/opensearch-project/ml-commons/pull/4817))
+* Introduce V2 Chat Agent ([#4732](https://github.com/opensearch-project/ml-commons/pull/4732))
+
 ### Enhancements
+
+* Add private IP security controls and ReDoS protection for ML connectors ([#4818](https://github.com/opensearch-project/ml-commons/pull/4818))
 * Add structured output (constrained decoding) support for agentic memory fact extraction ([#4824](https://github.com/opensearch-project/ml-commons/pull/4824))
+* Strengthen enforcement of `trusted_connector_endpoints_regex` across all outbound connector request paths ([#4826](https://github.com/opensearch-project/ml-commons/pull/4826))
+* Simplify USER_PREFERENCE extraction prompt to produce plain sentences, fixing silent JSON parse failures with smaller LLMs ([#4798](https://github.com/opensearch-project/ml-commons/pull/4798))
+
+### Bug Fixes
+
+* Fix Jackson exception handling due to 3.x release line migration ([#4784](https://github.com/opensearch-project/ml-commons/pull/4784))
+* Fix flaky `RestMLInferenceSearchResponseProcessorIT` connection pool timeout by optimizing test setup ([#4781](https://github.com/opensearch-project/ml-commons/pull/4781))
+* Fix tool output JSON escape issue when replacing placeholders in connector request bodies ([#4794](https://github.com/opensearch-project/ml-commons/pull/4794))
+* Propagate stream errors properly to callers instead of swallowing them ([#4792](https://github.com/opensearch-project/ml-commons/pull/4792))
+* Fix `model_parameters` being silently ignored in inferenceConfig and incorrect SourceType error message in V2 agents ([#4833](https://github.com/opensearch-project/ml-commons/pull/4833))
+
+### Infrastructure
+
+* Add issues write permission to untriaged label workflow ([#4827](https://github.com/opensearch-project/ml-commons/pull/4827))
+* Update Gradle to 9.4.1 and Jacoco to 0.8.14 to fix CI build failures ([#4811](https://github.com/opensearch-project/ml-commons/pull/4811))
+* Add `akolarkunnu` as maintainer ([#4788](https://github.com/opensearch-project/ml-commons/pull/4788))
+* Update GitHub username reference from `rithin-pullela-aws` to `rithinpullela` ([#4825](https://github.com/opensearch-project/ml-commons/pull/4825))
+
+### Documentation
+
+* Add Yandex Cloud AI Studio standard embedding connector blueprint ([#4810](https://github.com/opensearch-project/ml-commons/pull/4810))
+* Add Yandex Cloud AI Studio embeddings connector blueprint ([#4469](https://github.com/opensearch-project/ml-commons/pull/4469))
+
+### Maintenance
+
+* Support Jackson 3.x release line and update MCP SDK to 1.1.1 and json-schema-validation to 3.0.4 ([#4795](https://github.com/opensearch-project/ml-commons/pull/4795))

--- a/search-processors/build.gradle
+++ b/search-processors/build.gradle
@@ -22,6 +22,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     mavenLocal()
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+pluginManagement {
+    repositories {
+        maven { url "https://ci.opensearch.org/maven2/" }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'opensearch-ml'
 
 include 'client'

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -17,6 +17,7 @@ apply plugin: 'opensearch.java'
 
 repositories {
     mavenLocal()
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
 }


### PR DESCRIPTION
## Summary
- Fix flaky `RestChatAgentWithMcpConnectorIT.testChatAgentWithMcpStreamableHttpConnector`
- Root cause: `TransportMcpToolsRegisterOnNodesAction.registerToolsOnNode` uses `Flux...subscribe()` (fire-and-forget) and returns success before the reactive `addTool` Mono completes. So HTTP 200 from `/_plugins/_ml/mcp/tools/_register` does not guarantee the tool is visible to the MCP server's `/_list` yet
- The agent's MCP client then races the registration, gets back zero tools, and `BedrockConverseFunctionCalling` substitutes `tool_configs` to `, "toolConfig": {"tools": []}` — Bedrock Converse rejects an empty tools array with 400 `"The provided request is not valid"`
- Workaround in the test: poll `/_plugins/_ml/mcp/tools/_list` (15s max, 500ms cadence) until `ListIndexTool` appears, before continuing setup

## Test plan
- [x] Ran the IT 4 times locally with valid AWS Bedrock creds — 4/4 pass (1m27s first cold run, ~25s on warm cluster)
- [ ] Confirm passes on CI

## Out of scope (follow-up)
The deeper fix is upstream in `TransportMcpToolsRegisterOnNodesAction:114-144` — the reactive Mono should be awaited before returning success — and/or in `BedrockConverseFunctionCalling.configure` to drop `tool_configs` when `_tools` is empty. This PR only stabilizes the IT.